### PR TITLE
Avoid AOT compiler generation error

### DIFF
--- a/Assets/CHANGELOG.md
+++ b/Assets/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.0] - 2020-02-03
+
+### Changes
+
+* Split methods for ValueType and ReferenceType to avoid AOT compiler generation error
+
 ## [1.0.3] - 2020-02-03
 
 ### Fixes

--- a/Assets/README.md
+++ b/Assets/README.md
@@ -55,14 +55,17 @@ public class Foo
 
     public async Task Bar()
     {
-        var value = "";
+        var referenceTypeValue = "";
+        var valueTypeValue = 0;
 
         if (await KeyValueStore.Has("key"))
         {
-            value = await KeyValueStore.Get<string>("key", "default value");
+            referenceTypeValue = await KeyValueStore.GetReferenceType<string>("reference type key", "default value");
+            valueTypeValue = await KeyValueStore.GetReferenceType<int>("value type key", -1);
         }
 
-        await KeyValueStore.Set<string>("key", "value is " + value);
+        await KeyValueStore.SetReferenceType<string>("some key", $"reference type value is {referenceTypeValue} and value type value is {valueTypeValue}");
+        await KeyValueStore.SetValueType<bool>("some flag", true);
     }
 }
 ```

--- a/Assets/Scripts/Application/Interface/IKeyValueStore.cs
+++ b/Assets/Scripts/Application/Interface/IKeyValueStore.cs
@@ -1,4 +1,5 @@
 using System;
+using CAFU.KeyValueStore.Application.Utility;
 using JetBrains.Annotations;
 using UniRx.Async;
 
@@ -7,8 +8,10 @@ namespace CAFU.KeyValueStore.Application.Interface
     [PublicAPI]
     public interface IKeyValueStore
     {
-        UniTask<T> Get<T>(string key, T defaultValue = default, Func<string, T> deserializeCallback = default);
-        UniTask Set<T>(string key, T value, Func<T, string> serializeCallback = default);
+        UniTask<T> GetValueType<T>(string key, T defaultValue = default, Func<string, ReferenceWrapper<T>> deserializeCallback = default) where T : struct;
+        UniTask<T> GetReferenceType<T>(string key, T defaultValue = default, Func<string, T> deserializeCallback = default) where T : class;
+        UniTask SetValueType<T>(string key, T value, Func<ReferenceWrapper<T>, string> serializeCallback = default) where T : struct;
+        UniTask SetReferenceType<T>(string key, T value, Func<T, string> serializeCallback = default) where T : class;
         UniTask<bool> Has(string key);
     }
 }

--- a/Assets/Scripts/Application/Utility/ReferenceWrapper.cs
+++ b/Assets/Scripts/Application/Utility/ReferenceWrapper.cs
@@ -1,0 +1,42 @@
+namespace CAFU.KeyValueStore.Application.Utility
+{
+    public class ReferenceWrapper<T> where T : struct
+    {
+        private ReferenceWrapper(T value)
+        {
+            this.value = value;
+        }
+
+        private T value;
+
+        private T Value => value;
+
+        public override string ToString()
+        {
+            return value.ToString();
+        }
+
+        public static implicit operator T(ReferenceWrapper<T> wrapper)
+        {
+            return wrapper.Value;
+        }
+
+        public static implicit operator ReferenceWrapper<T>(T value)
+        {
+            return new ReferenceWrapper<T>(value);
+        }
+    }
+
+    public static class StructExtension
+    {
+        public static ReferenceWrapper<T> Wrap<T>(this T value) where T : struct
+        {
+            return value;
+        }
+
+        public static T Unwrap<T>(this ReferenceWrapper<T> wrappedValue) where T : struct
+        {
+            return wrappedValue;
+        }
+    }
+}

--- a/Assets/Scripts/Application/Utility/ReferenceWrapper.cs.meta
+++ b/Assets/Scripts/Application/Utility/ReferenceWrapper.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0388af8e0d234373807d06db35360e07
+timeCreated: 1580725587

--- a/Assets/Scripts/Application/Utility/Serialization.cs
+++ b/Assets/Scripts/Application/Utility/Serialization.cs
@@ -13,10 +13,20 @@ namespace CAFU.KeyValueStore.Application.Utility
             return JsonUtility.ToJson(value);
         }
 
-        public static string DateTime(DateTime value)
+        public static string ReferenceType<T>(T value) where T : class
+        {
+            return JsonUtility.ToJson(value);
+        }
+
+        public static string ValueType<T>(ReferenceWrapper<T> value) where T : struct
+        {
+            return JsonUtility.ToJson(value.Unwrap());
+        }
+
+        public static string DateTime(ReferenceWrapper<DateTime> value)
         {
             // ReSharper disable once StringLiteralTypo
-            return value.ToString("yyyyMMddHHmmssfff");
+            return value.Unwrap().ToString("yyyyMMddHHmmssfff");
         }
     }
 
@@ -28,10 +38,20 @@ namespace CAFU.KeyValueStore.Application.Utility
             return JsonUtility.FromJson<T>(value);
         }
 
-        public static DateTime DateTime(string value)
+        public static T ReferenceType<T>(string value) where T : class
+        {
+            return JsonUtility.FromJson<T>(value);
+        }
+
+        public static ReferenceWrapper<T> ValueType<T>(string value) where T : struct
+        {
+            return JsonUtility.FromJson<T>(value).Wrap();
+        }
+
+        public static ReferenceWrapper<DateTime> DateTime(string value)
         {
             // ReSharper disable once StringLiteralTypo
-            return System.DateTime.ParseExact(value, "yyyyMMddHHmmssfff", DateTimeFormatInfo.InvariantInfo, DateTimeStyles.None);
+            return System.DateTime.ParseExact(value, "yyyyMMddHHmmssfff", DateTimeFormatInfo.InvariantInfo, DateTimeStyles.None).Wrap();
         }
     }
 }

--- a/Assets/Scripts/Data/DataStore/Implement/PlayerPrefs.cs
+++ b/Assets/Scripts/Data/DataStore/Implement/PlayerPrefs.cs
@@ -1,4 +1,5 @@
 using System;
+using CAFU.KeyValueStore.Application.Utility;
 using CAFU.KeyValueStore.Data.Repository.Interface.DataStore;
 using JetBrains.Annotations;
 using UniRx.Async;
@@ -22,30 +23,37 @@ namespace CAFU.KeyValueStore.Data.DataStore.Implement
             }
 
             T result;
-            if (typeof(T) == typeof(bool))
+            if (typeof(T) == typeof(ReferenceWrapper<bool>))
             {
-                result = (T) (object) (UnityEngine.PlayerPrefs.GetInt(key, (bool)(object) defaultValue ? 1 : 0) == 1);
+                result = (T) (object) (UnityEngine.PlayerPrefs.GetInt(key, (defaultValue as ReferenceWrapper<bool>).Unwrap() ? 1 : 0) == 1).Wrap();
             }
-            else if (typeof(T) == typeof(int))
+            else if (typeof(T) == typeof(ReferenceWrapper<int>))
             {
-                result = (T) (object) UnityEngine.PlayerPrefs.GetInt(key, (int) (object) defaultValue);
+                result = (T) (object) UnityEngine.PlayerPrefs.GetInt(key, (defaultValue as ReferenceWrapper<int>).Unwrap()).Wrap();
             }
-            else if (typeof(T) == typeof(float))
+            else if (typeof(T) == typeof(ReferenceWrapper<float>))
             {
-                result = (T) (object) UnityEngine.PlayerPrefs.GetFloat(key, (float) (object) defaultValue);
+                result = (T) (object) UnityEngine.PlayerPrefs.GetFloat(key, (defaultValue as ReferenceWrapper<float>).Unwrap()).Wrap();
             }
             else if (typeof(T) == typeof(string))
             {
                 result = (T) (object) UnityEngine.PlayerPrefs.GetString(key, (string) (object) defaultValue);
             }
+            else if (deserializeCallback != default)
+            {
+                result = deserializeCallback(UnityEngine.PlayerPrefs.GetString(key));
+            }
             else
             {
-                if (deserializeCallback == default)
+                // Add `else if` when add Deserializer methods
+                if (typeof(T) == typeof(ReferenceWrapper<DateTime>))
+                {
+                    result = Deserializer.DateTime(UnityEngine.PlayerPrefs.GetString(key)) as T;
+                }
+                else
                 {
                     throw new ArgumentException($"Need third argument to get type of {typeof(T)}");
                 }
-
-                result = deserializeCallback(UnityEngine.PlayerPrefs.GetString(key));
             }
 
             return await UniTask.FromResult(result);
@@ -55,25 +63,35 @@ namespace CAFU.KeyValueStore.Data.DataStore.Implement
         {
             switch (value)
             {
-                case bool v:
+                case ReferenceWrapper<bool> v:
                     UnityEngine.PlayerPrefs.SetInt(key, v ? 1 : 0);
                     break;
-                case int v:
+                case ReferenceWrapper<int> v:
                     UnityEngine.PlayerPrefs.SetInt(key, v);
                     break;
-                case float v:
+                case ReferenceWrapper<float> v:
                     UnityEngine.PlayerPrefs.SetFloat(key, v);
                     break;
                 case string v:
                     UnityEngine.PlayerPrefs.SetString(key, v);
                     break;
                 default:
-                    if (serializeCallback == default)
+                    if (serializeCallback != default)
                     {
-                        throw new ArgumentException($"Need third argument to set type of {typeof(T)}");
+                        UnityEngine.PlayerPrefs.SetString(key, serializeCallback(value));
+                        break;
                     }
 
-                    UnityEngine.PlayerPrefs.SetString(key, serializeCallback(value));
+                    switch (value)
+                    {
+                        // Add `case` when add Serializer methods
+                        case ReferenceWrapper<DateTime> v:
+                            UnityEngine.PlayerPrefs.SetString(key, Serializer.DateTime(v));
+                            break;
+                        default:
+                            throw new ArgumentException($"Need third argument to set type of {typeof(T)}");
+                    }
+
                     break;
             }
 

--- a/Assets/Scripts/Data/Repository/Implement/KeyValueStoreHandler.cs
+++ b/Assets/Scripts/Data/Repository/Implement/KeyValueStoreHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using CAFU.KeyValueStore.Application.Interface;
+using CAFU.KeyValueStore.Application.Utility;
 using CAFU.KeyValueStore.Data.Repository.Interface.DataStore;
 using JetBrains.Annotations;
 using UniRx.Async;
@@ -22,12 +23,22 @@ namespace CAFU.KeyValueStore.Data.Repository.Implement
         private IAsyncSetter Setter { get; }
         private IAsyncChecker Checker { get; }
 
-        async UniTask<T> IKeyValueStore.Get<T>(string key, T defaultValue, Func<string, T> deserializeCallback)
+        async UniTask<T> IKeyValueStore.GetValueType<T>(string key, T defaultValue, Func<string, ReferenceWrapper<T>> deserializeCallback)
+        {
+            return (await Getter.GetAsync(key, defaultValue.Wrap(), deserializeCallback)).Unwrap();
+        }
+
+        async UniTask<T> IKeyValueStore.GetReferenceType<T>(string key, T defaultValue, Func<string, T> deserializeCallback)
         {
             return await Getter.GetAsync(key, defaultValue, deserializeCallback);
         }
 
-        async UniTask IKeyValueStore.Set<T>(string key, T value, Func<T, string> serializeCallback)
+        async UniTask IKeyValueStore.SetValueType<T>(string key, T value, Func<ReferenceWrapper<T>, string> serializeCallback)
+        {
+            await Setter.SetAsync(key, value.Wrap(), serializeCallback);
+        }
+
+        async UniTask IKeyValueStore.SetReferenceType<T>(string key, T value, Func<T, string> serializeCallback)
         {
             await Setter.SetAsync(key, value, serializeCallback);
         }

--- a/Assets/Scripts/Data/Repository/Interface/DataStore/IAsyncGetter.cs
+++ b/Assets/Scripts/Data/Repository/Interface/DataStore/IAsyncGetter.cs
@@ -5,6 +5,6 @@ namespace CAFU.KeyValueStore.Data.Repository.Interface.DataStore
 {
     internal interface IAsyncGetter
     {
-        UniTask<T> GetAsync<T>(string key, T defaultValue = default, Func<string, T> deserializeCallback = default);
+        UniTask<T> GetAsync<T>(string key, T defaultValue = default, Func<string, T> deserializeCallback = default) where T : class;
     }
 }

--- a/Assets/Scripts/Data/Repository/Interface/DataStore/IAsyncSetter.cs
+++ b/Assets/Scripts/Data/Repository/Interface/DataStore/IAsyncSetter.cs
@@ -5,6 +5,6 @@ namespace CAFU.KeyValueStore.Data.Repository.Interface.DataStore
 {
     internal interface IAsyncSetter
     {
-        UniTask SetAsync<T>(string key, T value, Func<T, string> serializeCallback = default);
+        UniTask SetAsync<T>(string key, T value, Func<T, string> serializeCallback = default) where T : class;
     }
 }

--- a/Assets/Tests/Runtime/Scripts/取得.cs
+++ b/Assets/Tests/Runtime/Scripts/取得.cs
@@ -56,7 +56,7 @@ namespace CAFU.KeyValueStore
             PlayerPrefs.SetString(Key, "値を取得");
 
             yield return KeyValueStore
-                .Get<string>(Key)
+                .GetReferenceType<string>(Key)
                 .ToCoroutine(
                     x => Assert.That(x, Is.EqualTo("値を取得"))
                 );
@@ -71,16 +71,16 @@ namespace CAFU.KeyValueStore
             PlayerPrefs.SetString(Key + "String", "string value");
 
             yield return KeyValueStore
-                .Get<bool>(Key + "Bool")
+                .GetValueType<bool>(Key + "Bool")
                 .ToCoroutine(x => Assert.That(x, Is.True));
             yield return KeyValueStore
-                .Get<int>(Key + "Int")
+                .GetValueType<int>(Key + "Int")
                 .ToCoroutine(x => Assert.That(x, Is.EqualTo(2)));
             yield return KeyValueStore
-                .Get<float>(Key + "Float")
+                .GetValueType<float>(Key + "Float")
                 .ToCoroutine(x => Assert.That(x, Is.EqualTo(100.0f)));
             yield return KeyValueStore
-                .Get<string>(Key + "String")
+                .GetReferenceType<string>(Key + "String")
                 .ToCoroutine(x => Assert.That(x, Is.EqualTo("string value")));
         }
 
@@ -93,7 +93,7 @@ namespace CAFU.KeyValueStore
             PlayerPrefs.SetString(Key + "DateTime", Serializer.DateTime(dateTimeNow));
 
             yield return KeyValueStore
-                .Get(Key + "Custom", deserializeCallback: Deserializer.Default<CustomClass>)
+                .GetReferenceType(Key + "Custom", deserializeCallback: Deserializer.Default<CustomClass>)
                 .ToCoroutine(
                     x =>
                     {
@@ -102,7 +102,7 @@ namespace CAFU.KeyValueStore
                     }
                 );
             yield return KeyValueStore
-                .Get(Key + "DateTime", deserializeCallback: Deserializer.DateTime)
+                .GetValueType(Key + "DateTime", deserializeCallback: Deserializer.DateTime)
                 .ToCoroutine(
                     x =>
                     {
@@ -120,7 +120,7 @@ namespace CAFU.KeyValueStore
         public IEnumerator D_デフォルト値を取得できる()
         {
             yield return KeyValueStore
-                .Get(Key, "デフォルト値を取得")
+                .GetReferenceType(Key, "デフォルト値を取得")
                 .ToCoroutine(
                     x => Assert.That(x, Is.EqualTo("デフォルト値を取得"))
                 );

--- a/Assets/Tests/Runtime/Scripts/設定.cs
+++ b/Assets/Tests/Runtime/Scripts/設定.cs
@@ -54,7 +54,7 @@ namespace CAFU.KeyValueStore
         public IEnumerator A_値を設定できる()
         {
             yield return KeyValueStore
-                .Set(Key, "値を設定")
+                .SetReferenceType(Key, "値を設定")
                 .ToCoroutine();
 
             Assert.That(PlayerPrefs.GetString(Key), Is.EqualTo("値を設定"));
@@ -64,16 +64,16 @@ namespace CAFU.KeyValueStore
         public IEnumerator B_プリミティブ型の値を設定できる()
         {
             yield return KeyValueStore
-                .Set(Key + "Bool", true)
+                .SetValueType(Key + "Bool", true)
                 .ToCoroutine();
             yield return KeyValueStore
-                .Set(Key + "Int", 2)
+                .SetValueType(Key + "Int", 2)
                 .ToCoroutine();
             yield return KeyValueStore
-                .Set(Key + "Float", 100.0f)
+                .SetValueType(Key + "Float", 100.0f)
                 .ToCoroutine();
             yield return KeyValueStore
-                .Set(Key + "String", "string value")
+                .SetReferenceType(Key + "String", "string value")
                 .ToCoroutine();
 
             Assert.That(PlayerPrefs.GetInt(Key + "Bool") == 1, Is.True);
@@ -89,14 +89,14 @@ namespace CAFU.KeyValueStore
             var dateTimeNow = DateTime.Now;
 
             yield return KeyValueStore
-                .Set(Key + "Custom", customClass, Serializer.Default)
+                .SetReferenceType(Key + "Custom", customClass, Serializer.Default)
                 .ToCoroutine(
                     x =>
                     {
                     }
                 );
             yield return KeyValueStore
-                .Set(Key + "DateTime", dateTimeNow, Serializer.DateTime)
+                .SetValueType(Key + "DateTime", dateTimeNow, Serializer.DateTime)
                 .ToCoroutine();
 
             {
@@ -105,7 +105,7 @@ namespace CAFU.KeyValueStore
                 Assert.That(x.StringValue, Is.EqualTo(customClass.StringValue));
             }
             {
-                var x = Deserializer.DateTime(PlayerPrefs.GetString(Key + "DateTime"));
+                var x = Deserializer.DateTime(PlayerPrefs.GetString(Key + "DateTime")).Unwrap();
                 Assert.That(x.Year, Is.EqualTo(dateTimeNow.Year));
                 Assert.That(x.Month, Is.EqualTo(dateTimeNow.Month));
                 Assert.That(x.Day, Is.EqualTo(dateTimeNow.Day));

--- a/Assets/package.json
+++ b/Assets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dev.upm-packages.cafu.keyvaluestore",
   "displayName": "CAFU KeyValueStore",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "unity": "2019.2",
   "description": "Provides a simple Key-Value store",
   "author": {


### PR DESCRIPTION
* IL2CPP コンパイラは interface に生えた Generic メソッドに対して値型のソレを生成してくれないため、無理矢理参照型に変換するコトでこれを回避する